### PR TITLE
Added Stream.Source() method to access the underlying source

### DIFF
--- a/streamcache.go
+++ b/streamcache.go
@@ -152,6 +152,18 @@ func (s *Stream) NewReader(ctx context.Context) *Reader {
 	return r
 }
 
+// Source returns the Stream's underlying source io.Reader.
+// This can be useful if you need to force close the source
+// for some reason, e.g.
+//
+//	stream.Source().(io.Closer).Close()
+//
+// The Stream's behavior is undefined if the caller reads from
+// the source directly.
+func (s *Stream) Source() io.Reader {
+	return s.src
+}
+
 // readFunc is the type of the Reader.readFn field.
 type readFunc func(r *Reader, p []byte, offset int) (n int, err error)
 


### PR DESCRIPTION
From experience, there are circumstances where it's useful to access the `Stream`'s underlying source, e.g. force-closing a file source on exit. To this end, there's now a `Stream.Source()` method.