### PR TITLE
Add MaxCacheSize option to bound the in-memory cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 *.iml
 .idea
 
+# Local superpowers specs/plans (not committed)
+docs/superpowers/
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/README.md
+++ b/README.md
@@ -109,6 +109,29 @@ hello world
 Read 12 bytes from stdin
 ```
 
+## Limiting cache size
+
+By default, a `Stream` caches in memory every byte read from the source until
+the stream is sealed down to its final reader. For an unbounded source, use the
+`MaxCacheSize` option to cap how much the stream will buffer:
+
+```go
+stream := streamcache.New(os.Stdin, streamcache.MaxCacheSize(1_000_000))
+
+r := stream.NewReader(ctx)
+if _, err := io.Copy(dst, r); err != nil {
+    if errors.Is(err, streamcache.ErrCacheLimit) {
+        // The source exceeded the 1MB cache limit.
+    }
+}
+```
+
+If the source yields more than the configured limit, `Reader.Read` returns
+`streamcache.ErrCacheLimit` and the stream enters a terminal error state
+(`Stream.Err` returns `ErrCacheLimit`). The limit does not apply to the final
+reader once the stream is sealed, since that reader reads directly from the
+source and does not use the cache.
+
 ## Examples
 
 - [`in-out-err`](./examples/in-out-err): copy `stdin` to both `stdout` and `stderr`.

--- a/README.md
+++ b/README.md
@@ -116,21 +116,23 @@ the stream is sealed down to its final reader. For an unbounded source, use the
 `MaxCacheSize` option to cap how much the stream will buffer:
 
 ```go
+ctx := context.Background()
 stream := streamcache.New(os.Stdin, streamcache.MaxCacheSize(1_000_000))
 
 r := stream.NewReader(ctx)
-if _, err := io.Copy(dst, r); err != nil {
+defer r.Close()
+if _, err := io.Copy(os.Stdout, r); err != nil {
     if errors.Is(err, streamcache.ErrCacheLimit) {
-        // The source exceeded the 1MB cache limit.
+        // The source exceeded the 1 MB cache limit.
     }
 }
 ```
 
 If the source yields more than the configured limit, `Reader.Read` returns
 `streamcache.ErrCacheLimit` and the stream enters a terminal error state
-(`Stream.Err` returns `ErrCacheLimit`). The limit does not apply to the final
-reader once the stream is sealed, since that reader reads directly from the
-source and does not use the cache.
+(`Stream.Err` returns `streamcache.ErrCacheLimit`). The limit does not apply to
+the final reader once the stream is sealed, since that reader reads directly
+from the source and does not use the cache.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ if _, err := io.Copy(os.Stdout, r); err != nil {
 
 If the source yields more than the configured limit, `Reader.Read` returns
 `streamcache.ErrCacheLimit` and the stream enters a terminal error state
-(`Stream.Err` returns `streamcache.ErrCacheLimit`). The limit does not apply to
-the final reader once the stream is sealed, since that reader reads directly
-from the source and does not use the cache.
+(`Stream.Err` returns `streamcache.ErrCacheLimit`). If the read that crosses the
+limit also returns a genuine (non-`io.EOF`) error from the source, that source
+error is reported instead. The limit does not apply to the final reader once the
+stream is sealed, since that reader reads directly from the source and does not
+use the cache.
 
 ## Examples
 

--- a/streamcache.go
+++ b/streamcache.go
@@ -339,6 +339,23 @@ TOP:
 		}
 	}
 
+	// Before growing the cache, enforce the cache size limit, if one is set. If
+	// the cache has already grown beyond the limit, we refuse to read more from
+	// src, and put the Stream into a terminal error state with ErrCacheLimit.
+	// Reading s.size here is safe: we hold the src lock, and only the src lock
+	// holder mutates s.size while the cache is in use.
+	if s.maxCacheSize > 0 && s.size > s.maxCacheSize {
+		s.cMu.Lock() // write lock
+		if s.readErr == nil {
+			s.readErr = ErrCacheLimit
+			close(s.srcDoneCh)
+		}
+		err = s.readErr
+		s.cMu.Unlock()   // write unlock
+		s.srcMu.Unlock() // src unlock
+		return 0, err
+	}
+
 	// OK, this time, we're REALLY going to read from src.
 	n, err = s.src.Read(p)
 	if n == 0 && err == nil {

--- a/streamcache.go
+++ b/streamcache.go
@@ -144,7 +144,8 @@ func (f optionFunc) apply(s *Stream) { f(s) }
 // The limit applies only while the cache is in use: once the Stream is sealed
 // (see Stream.Seal) and only the final Reader remains, that Reader reads
 // directly from the source, bypassing the cache, and is not subject to the
-// limit.
+// limit. If the limit was already exceeded before sealing, however, the Stream
+// is already in its terminal error state, and sealing does not lift it.
 //
 // Because detecting that the source has more than n bytes requires reading past
 // n, the cache may exceed n by up to one source read: the read that grows the

--- a/streamcache.go
+++ b/streamcache.go
@@ -143,8 +143,10 @@ func (f optionFunc) apply(s *Stream) { f(s) }
 // limit.
 //
 // Because detecting that the source exceeds n bytes requires reading past n,
-// the cache may transiently grow by up to one source read beyond n before
-// ErrCacheLimit is returned.
+// the cache may grow by up to one source read beyond n. A source whose total
+// size falls within that overshoot window may therefore be read to completion
+// (returning io.EOF) without ErrCacheLimit ever being returned. The guarantee
+// is that the cache will not grow unboundedly, not that it never exceeds n.
 func MaxCacheSize(n int) Option {
 	return optionFunc(func(s *Stream) {
 		s.maxCacheSize = n

--- a/streamcache.go
+++ b/streamcache.go
@@ -541,19 +541,19 @@ func (s *Stream) Size() int {
 	return s.size
 }
 
-// Total blocks until the source reader is fully read, and returns the total
-// number of bytes read from the source, and any read error other than io.EOF
-// returned by the source. If ctx is cancelled, zero and the context's cause
-// error (per context.Cause) are returned. If source returned a non-EOF error,
-// that error and the total number of bytes read are returned.
+// Total blocks until the Stream reaches a terminal state — the source is fully
+// read (io.EOF), the source returns a non-EOF error, or the cache size limit
+// (see MaxCacheSize) is exceeded — and returns the number of bytes read from the
+// source so far, along with any terminal error other than io.EOF. When the
+// cache size limit is what ended the stream, the returned size may be less than
+// the source's full length. If ctx is cancelled, zero and the context's cause
+// error (per context.Cause) are returned. If the source returned a non-EOF
+// error, that error and the number of bytes read are returned.
 //
 // Note that Total only returns if the channel returned by Stream.Filled
 // is closed, but Total can return even if Stream.Done is not closed.
 // That is to say, Total returning does not necessarily mean that all readers
 // are closed.
-//
-// If the cache size limit configured via MaxCacheSize is exceeded, Total
-// returns the number of bytes cached so far and ErrCacheLimit.
 //
 // See also: Stream.Size, Stream.Err, Stream.Filled, Stream.Done.
 func (s *Stream) Total(ctx context.Context) (size int, err error) {
@@ -576,13 +576,11 @@ func (s *Stream) Total(ctx context.Context) (size int, err error) {
 	}
 }
 
-// Err returns the first error (if any) that was returned by the underlying
-// source reader, which may be io.EOF. After the source reader returns an
-// error, it is never read from again, and the channel returned by Stream.Filled
-// is closed.
-//
-// Err also returns ErrCacheLimit if the cache size limit configured via
-// MaxCacheSize was exceeded.
+// Err returns the first error (if any) that put the Stream into its terminal
+// state: an error returned by the underlying source reader (which may be
+// io.EOF), or ErrCacheLimit if the cache size limit (see MaxCacheSize) was
+// exceeded. Once the Stream is terminal, the source is never read from again,
+// and the channel returned by Stream.Filled is closed.
 func (s *Stream) Err() error {
 	s.cMu.RLock()         // read lock
 	defer s.cMu.RUnlock() // read unlock

--- a/streamcache.go
+++ b/streamcache.go
@@ -45,6 +45,10 @@ import (
 // already closed.
 var ErrAlreadyClosed = errors.New("reader is already closed")
 
+// ErrCacheLimit is returned by Reader.Read when the cache size limit
+// configured via MaxCacheSize is exceeded. See MaxCacheSize.
+var ErrCacheLimit = errors.New("cache size limit exceeded")
+
 // Stream mediates access to the bytes of an underlying source io.Reader.
 // Multiple callers can invoke Stream.NewReader to obtain a Reader, each of
 // which can read the full or partial contents of the source reader. Note that
@@ -91,6 +95,13 @@ type Stream struct {
 	// size is the count of bytes read from src.
 	size int
 
+	// maxCacheSize is the maximum number of bytes that cache may hold. If the
+	// source yields more bytes than this, readMain returns ErrCacheLimit and
+	// the Stream enters a terminal error state. A value <= 0 means no limit. It
+	// is set once by New and never mutated thereafter, so it is safe to read
+	// without holding a lock. See MaxCacheSize.
+	maxCacheSize int
+
 	// cMu guards concurrent access to Stream's fields and methods.
 	cMu sync.RWMutex
 
@@ -109,13 +120,53 @@ type Stream struct {
 	// src locks.
 }
 
-// New returns a new Stream that wraps src. Use Stream.NewReader to read from src.
-func New(src io.Reader) *Stream {
+// Option is a configuration option for New.
+type Option interface {
+	apply(s *Stream)
+}
+
+// optionFunc adapts a function to the Option interface.
+type optionFunc func(s *Stream)
+
+func (f optionFunc) apply(s *Stream) { f(s) }
+
+// MaxCacheSize returns an Option for New that caps the number of bytes that the
+// Stream will buffer in its in-memory cache. If the source contains more than n
+// bytes, a Reader.Read that would grow the cache beyond n returns ErrCacheLimit,
+// and the Stream thereafter is in a terminal error state (see Stream.Err).
+//
+// A value of n <= 0 (the default) means no limit.
+//
+// The limit applies only while the cache is in use: once the Stream is sealed
+// (see Stream.Seal) and only the final Reader remains, that Reader reads
+// directly from the source, bypassing the cache, and is not subject to the
+// limit.
+//
+// Because detecting that the source exceeds n bytes requires reading past n,
+// the cache may transiently grow by up to one source read beyond n before
+// ErrCacheLimit is returned.
+func MaxCacheSize(n int) Option {
+	return optionFunc(func(s *Stream) {
+		s.maxCacheSize = n
+	})
+}
+
+// New returns a new Stream that wraps src, configured by any provided opts. Use
+// Stream.NewReader to read from src.
+//
+// See MaxCacheSize for an option that bounds the Stream's memory use.
+func New(src io.Reader, opts ...Option) *Stream {
 	c := &Stream{
 		src:        src,
 		cache:      make([]byte, 0),
 		rdrsDoneCh: make(chan struct{}),
 		srcDoneCh:  make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt.apply(c)
+		}
 	}
 
 	return c

--- a/streamcache.go
+++ b/streamcache.go
@@ -366,7 +366,12 @@ TOP:
 	// greater-than, so a source of exactly maxCacheSize bytes does not trip it.
 	// Because the limit is enforced here, on every append, the cache can exceed
 	// maxCacheSize by at most one source read before the Stream is terminated.
-	if s.maxCacheSize > 0 && s.size > s.maxCacheSize {
+	//
+	// A genuine source error returned by this same read takes precedence: it is
+	// more diagnostic than ErrCacheLimit, so we only override err when src
+	// returned no error or io.EOF (io.EOF being normal completion, not a
+	// failure, is superseded by ErrCacheLimit).
+	if s.maxCacheSize > 0 && s.size > s.maxCacheSize && (err == nil || errors.Is(err, io.EOF)) {
 		err = ErrCacheLimit
 	}
 	s.readErr = err

--- a/streamcache.go
+++ b/streamcache.go
@@ -45,8 +45,10 @@ import (
 // already closed.
 var ErrAlreadyClosed = errors.New("reader is already closed")
 
-// ErrCacheLimit is returned by Reader.Read when the cache size limit
-// configured via MaxCacheSize is exceeded. See MaxCacheSize.
+// ErrCacheLimit is returned by Reader.Read when the Stream terminates because
+// the cache size limit configured via MaxCacheSize was exceeded. If the read
+// that crosses the limit also returns a non-EOF error from the source, that
+// source error is reported instead. See MaxCacheSize.
 var ErrCacheLimit = errors.New("cache size limit exceeded")
 
 // Stream mediates access to the bytes of an underlying source io.Reader.
@@ -132,8 +134,10 @@ func (f optionFunc) apply(s *Stream) { f(s) }
 
 // MaxCacheSize returns an Option for New that caps the number of bytes that the
 // Stream will buffer in its in-memory cache. If the source contains more than n
-// bytes, a Reader.Read that would grow the cache beyond n returns ErrCacheLimit,
-// and the Stream thereafter is in a terminal error state (see Stream.Err).
+// bytes, the Reader.Read that grows the cache beyond n returns ErrCacheLimit
+// (unless that read also returns a non-EOF source error, which is reported
+// instead), and the Stream thereafter is in a terminal error state (see
+// Stream.Err).
 //
 // A value of n <= 0 (the default) means no limit.
 //
@@ -145,9 +149,11 @@ func (f optionFunc) apply(s *Stream) { f(s) }
 // Because detecting that the source has more than n bytes requires reading past
 // n, the cache may exceed n by up to one source read: the read that grows the
 // cache beyond n returns ErrCacheLimit together with the bytes it read, and the
-// Stream enters a terminal error state (see Stream.Err). A source of exactly n
-// bytes completes normally with io.EOF. The guarantee is that the cache will not
-// grow unboundedly, not that it never exceeds n.
+// Stream enters a terminal error state (see Stream.Err). If that same read also
+// returns a non-EOF error from the source, the source error is reported instead,
+// as it is more diagnostic. A source of exactly n bytes completes normally with
+// io.EOF. The guarantee is that the cache will not grow unboundedly, not that it
+// never exceeds n.
 func MaxCacheSize(n int) Option {
 	return optionFunc(func(s *Stream) {
 		s.maxCacheSize = n

--- a/streamcache.go
+++ b/streamcache.go
@@ -517,9 +517,10 @@ func (s *Stream) Done() <-chan struct{} {
 }
 
 // Filled returns a channel that is closed when the underlying source reader
-// returns an error, including io.EOF. If the source reader returns an error, it
-// is never read from again. If the source reader does not return an error, this
-// channel is never closed.
+// returns an error, including io.EOF, or when the cache size limit configured
+// via MaxCacheSize is exceeded. If the source reader returns an error, it is
+// never read from again. If the source reader does not return an error and the
+// cache size limit is not exceeded, this channel is never closed.
 //
 // See also: Stream.Done.
 func (s *Stream) Filled() <-chan struct{} {
@@ -547,6 +548,9 @@ func (s *Stream) Size() int {
 // That is to say, Total returning does not necessarily mean that all readers
 // are closed.
 //
+// If the cache size limit configured via MaxCacheSize is exceeded, Total
+// returns the number of bytes cached so far and ErrCacheLimit.
+//
 // See also: Stream.Size, Stream.Err, Stream.Filled, Stream.Done.
 func (s *Stream) Total(ctx context.Context) (size int, err error) {
 	if ctx == nil {
@@ -572,6 +576,9 @@ func (s *Stream) Total(ctx context.Context) (size int, err error) {
 // source reader, which may be io.EOF. After the source reader returns an
 // error, it is never read from again, and the channel returned by Stream.Filled
 // is closed.
+//
+// Err also returns ErrCacheLimit if the cache size limit configured via
+// MaxCacheSize was exceeded.
 func (s *Stream) Err() error {
 	s.cMu.RLock()         // read lock
 	defer s.cMu.RUnlock() // read unlock

--- a/streamcache.go
+++ b/streamcache.go
@@ -142,11 +142,12 @@ func (f optionFunc) apply(s *Stream) { f(s) }
 // directly from the source, bypassing the cache, and is not subject to the
 // limit.
 //
-// Because detecting that the source exceeds n bytes requires reading past n,
-// the cache may grow by up to one source read beyond n. A source whose total
-// size falls within that overshoot window may therefore be read to completion
-// (returning io.EOF) without ErrCacheLimit ever being returned. The guarantee
-// is that the cache will not grow unboundedly, not that it never exceeds n.
+// Because detecting that the source has more than n bytes requires reading past
+// n, the cache may exceed n by up to one source read: the read that grows the
+// cache beyond n returns ErrCacheLimit together with the bytes it read, and the
+// Stream enters a terminal error state (see Stream.Err). A source of exactly n
+// bytes completes normally with io.EOF. The guarantee is that the cache will not
+// grow unboundedly, not that it never exceeds n.
 func MaxCacheSize(n int) Option {
 	return optionFunc(func(s *Stream) {
 		s.maxCacheSize = n
@@ -341,23 +342,6 @@ TOP:
 		}
 	}
 
-	// Before growing the cache, enforce the cache size limit, if one is set. If
-	// the cache has already grown beyond the limit, we refuse to read more from
-	// src, and put the Stream into a terminal error state with ErrCacheLimit.
-	// Reading s.size here is safe: we hold the src lock, and only the src lock
-	// holder mutates s.size while the cache is in use.
-	if s.maxCacheSize > 0 && s.size > s.maxCacheSize {
-		s.cMu.Lock() // write lock
-		if s.readErr == nil {
-			s.readErr = ErrCacheLimit
-			close(s.srcDoneCh)
-		}
-		err = s.readErr
-		s.cMu.Unlock()   // write unlock
-		s.srcMu.Unlock() // src unlock
-		return 0, err
-	}
-
 	// OK, this time, we're REALLY going to read from src.
 	n, err = s.src.Read(p)
 	if n == 0 && err == nil {
@@ -369,14 +353,27 @@ TOP:
 
 	// Now we need to update the cache, so we need to get the write lock.
 	s.cMu.Lock() // write lock
-	s.readErr = err
 	if n > 0 {
 		s.size += n
 		s.cache = append(s.cache, p[:n]...)
 	}
 
+	// Enforce the cache size limit, if one is set. If this read grew the cache
+	// beyond the limit, the Stream is terminally over-limit: we report
+	// ErrCacheLimit (along with the bytes just read) instead of src's error, so
+	// that the terminal state is established the moment the cache crosses the
+	// limit, rather than on a subsequent read. The check is strictly
+	// greater-than, so a source of exactly maxCacheSize bytes does not trip it.
+	// Because the limit is enforced here, on every append, the cache can exceed
+	// maxCacheSize by at most one source read before the Stream is terminated.
+	if s.maxCacheSize > 0 && s.size > s.maxCacheSize {
+		err = ErrCacheLimit
+	}
+	s.readErr = err
+
 	if err != nil {
-		// We received an error from src, so it's done.
+		// Either src returned an error, or we hit the cache limit. Either way,
+		// src is never read from again, so the Stream is done.
 		close(s.srcDoneCh)
 	}
 

--- a/streamcache_test.go
+++ b/streamcache_test.go
@@ -978,6 +978,55 @@ func TestMaxCacheSize_Concurrent(t *testing.T) {
 	require.True(t, errors.Is(s.Err(), streamcache.ErrCacheLimit))
 }
 
+func TestMaxCacheSize_TerminalOnOverflowRead(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		limit   = 1000
+		bufSize = 4096 // a single read overshoots the limit
+		srcSize = 100_000
+	)
+	s := streamcache.New(newLimitRandReader(srcSize), streamcache.MaxCacheSize(limit))
+	r := s.NewReader(ctx)
+	defer r.Close()
+
+	// The single read that grows the cache past the limit returns ErrCacheLimit
+	// on that same call (with the bytes it read), and sets the terminal state
+	// immediately — no further read is required.
+	buf := make([]byte, bufSize)
+	n, err := r.Read(buf)
+	require.True(t, errors.Is(err, streamcache.ErrCacheLimit))
+	require.Greater(t, n, 0)
+
+	// Terminal state is reflected without any further read.
+	require.True(t, errors.Is(s.Err(), streamcache.ErrCacheLimit))
+	requireTake(t, s.Filled())
+	size, errTotal := s.Total(ctx)
+	require.True(t, errors.Is(errTotal, streamcache.ErrCacheLimit))
+	require.Greater(t, size, limit)
+}
+
+func TestMaxCacheSize_OverLimitWithBundledEOF(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const limit = 1000
+	// A source that returns more than `limit` bytes together with io.EOF in a
+	// single read still reports ErrCacheLimit (the source exceeded the limit),
+	// not io.EOF.
+	src := &tweakableReader{data: make([]byte, limit+500), err: io.EOF}
+	s := streamcache.New(src, streamcache.MaxCacheSize(limit))
+	r := s.NewReader(ctx)
+	defer r.Close()
+
+	buf := make([]byte, limit+500)
+	n, err := r.Read(buf)
+	require.Equal(t, limit+500, n)
+	require.True(t, errors.Is(err, streamcache.ErrCacheLimit))
+	require.True(t, errors.Is(s.Err(), streamcache.ErrCacheLimit))
+}
+
 func TestStreamSource(t *testing.T) {
 	t.Parallel()
 

--- a/streamcache_test.go
+++ b/streamcache_test.go
@@ -808,6 +808,40 @@ func TestMaxCacheSize_APIAndBackwardCompat(t *testing.T) {
 	require.NotNil(t, streamcache.ErrCacheLimit)
 }
 
+func TestMaxCacheSize_Overflow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		limit   = 1000
+		srcSize = 200_000
+	)
+	s := streamcache.New(newLimitRandReader(srcSize), streamcache.MaxCacheSize(limit))
+
+	// r1 reads until the cache overflows.
+	r1 := s.NewReader(ctx)
+	defer r1.Close()
+	n1, err := io.Copy(io.Discard, r1)
+	require.True(t, errors.Is(err, streamcache.ErrCacheLimit))
+	require.Greater(t, n1, int64(limit)) // got the overshoot bytes
+	require.Less(t, n1, int64(srcSize))  // but not the whole source
+
+	// The whole Stream is now terminally errored.
+	require.True(t, errors.Is(s.Err(), streamcache.ErrCacheLimit))
+	requireTake(t, s.Filled())
+
+	size, errTotal := s.Total(ctx)
+	require.True(t, errors.Is(errTotal, streamcache.ErrCacheLimit))
+	require.Greater(t, size, limit)
+
+	// A second reader drains the cached bytes, then also sees ErrCacheLimit.
+	r2 := s.NewReader(ctx)
+	defer r2.Close()
+	n2, err := io.Copy(io.Discard, r2)
+	require.True(t, errors.Is(err, streamcache.ErrCacheLimit))
+	require.Equal(t, n1, n2) // r2 drains exactly the cached bytes
+}
+
 func TestStreamSource(t *testing.T) {
 	t.Parallel()
 

--- a/streamcache_test.go
+++ b/streamcache_test.go
@@ -783,6 +783,31 @@ func TestReadFinal_Overlap(t *testing.T) {
 	require.NoError(t, r2.Close())
 }
 
+func TestMaxCacheSize_APIAndBackwardCompat(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// New with no options behaves exactly as before.
+	s1 := streamcache.New(strings.NewReader(anything))
+	r1 := s1.NewReader(ctx)
+	defer r1.Close()
+	b1, err := io.ReadAll(r1)
+	require.NoError(t, err)
+	require.Equal(t, anything, string(b1))
+
+	// New accepts MaxCacheSize; a limit larger than the source is never hit.
+	s2 := streamcache.New(strings.NewReader(anything), streamcache.MaxCacheSize(1<<20))
+	r2 := s2.NewReader(ctx)
+	defer r2.Close()
+	b2, err := io.ReadAll(r2)
+	require.NoError(t, err)
+	require.Equal(t, anything, string(b2))
+	require.False(t, errors.Is(s2.Err(), streamcache.ErrCacheLimit))
+
+	// ErrCacheLimit is a defined sentinel.
+	require.NotNil(t, streamcache.ErrCacheLimit)
+}
+
 func TestStreamSource(t *testing.T) {
 	t.Parallel()
 

--- a/streamcache_test.go
+++ b/streamcache_test.go
@@ -917,6 +917,67 @@ func TestMaxCacheSize_OverflowThenSeal(t *testing.T) {
 	require.NoError(t, r2.Close())
 }
 
+func TestMaxCacheSize_OvershootBound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		limit   = 4096
+		bufSize = 1024
+		srcSize = 1 << 20
+	)
+	s := streamcache.New(newLimitRandReader(srcSize), streamcache.MaxCacheSize(limit))
+	r := s.NewReader(ctx)
+	defer r.Close()
+
+	buf := make([]byte, bufSize)
+	var err error
+	for err == nil {
+		_, err = r.Read(buf)
+	}
+	require.True(t, errors.Is(err, streamcache.ErrCacheLimit))
+
+	// The cache strictly exceeds the limit (the crossing read is kept) by at
+	// most one source read (the consuming reader's buffer length).
+	cache := streamcache.CacheInternal(s)
+	require.Greater(t, len(cache), limit)
+	require.LessOrEqual(t, len(cache), limit+bufSize)
+}
+
+func TestMaxCacheSize_Concurrent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		limit      = 1000
+		srcSize    = 200_000
+		numReaders = 8
+	)
+	src := newDelayReader(newLimitRandReader(srcSize), time.Microsecond, true)
+	s := streamcache.New(src, streamcache.MaxCacheSize(limit))
+
+	errs := make([]error, numReaders)
+	var wg sync.WaitGroup
+	for i := range numReaders {
+		r := s.NewReader(ctx)
+		wg.Add(1)
+		go func(i int, r *streamcache.Reader) {
+			defer wg.Done()
+			defer r.Close()
+			_, errs[i] = io.Copy(io.Discard, r)
+		}(i, r)
+	}
+	wg.Wait()
+
+	// The source is far larger than the limit, so every reader eventually needs
+	// bytes beyond the cap and ends with ErrCacheLimit.
+	for i := range errs {
+		require.Truef(t, errors.Is(errs[i], streamcache.ErrCacheLimit),
+			"reader %d: got %v", i, errs[i])
+	}
+	require.True(t, errors.Is(s.Err(), streamcache.ErrCacheLimit))
+}
+
 func TestStreamSource(t *testing.T) {
 	t.Parallel()
 

--- a/streamcache_test.go
+++ b/streamcache_test.go
@@ -842,6 +842,81 @@ func TestMaxCacheSize_Overflow(t *testing.T) {
 	require.Equal(t, n1, n2) // r2 drains exactly the cached bytes
 }
 
+func TestMaxCacheSize_ExactFit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const limit = 1000
+	// Source is exactly limit bytes: must complete with io.EOF, not overflow.
+	s := streamcache.New(bytes.NewReader(make([]byte, limit)), streamcache.MaxCacheSize(limit))
+	r := s.NewReader(ctx)
+	defer r.Close()
+
+	n, err := io.Copy(io.Discard, r)
+	require.NoError(t, err)
+	require.Equal(t, int64(limit), n)
+	require.True(t, errors.Is(s.Err(), io.EOF))
+}
+
+func TestMaxCacheSize_Unlimited(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const srcSize = 100_000
+	for _, limit := range []int{0, -1} {
+		s := streamcache.New(newLimitRandReader(srcSize), streamcache.MaxCacheSize(limit))
+		r := s.NewReader(ctx)
+		n, err := io.Copy(io.Discard, r)
+		require.NoError(t, err)
+		require.Equal(t, int64(srcSize), n)
+		require.NoError(t, r.Close())
+	}
+}
+
+func TestMaxCacheSize_DirectReadNotLimited(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		limit   = 1000
+		srcSize = 100_000
+	)
+	s := streamcache.New(newLimitRandReader(srcSize), streamcache.MaxCacheSize(limit))
+	r := s.NewReader(ctx)
+	s.Seal() // single reader + sealed => reads directly from src, bypassing cache
+
+	n, err := io.Copy(io.Discard, r)
+	require.NoError(t, err)
+	require.Equal(t, int64(srcSize), n)
+	require.NoError(t, r.Close())
+}
+
+func TestMaxCacheSize_OverflowThenSeal(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const (
+		limit   = 1000
+		srcSize = 100_000
+	)
+	s := streamcache.New(newLimitRandReader(srcSize), streamcache.MaxCacheSize(limit))
+	r1 := s.NewReader(ctx)
+	r2 := s.NewReader(ctx)
+
+	// r1 trips the overflow.
+	_, err := io.Copy(io.Discard, r1)
+	require.True(t, errors.Is(err, streamcache.ErrCacheLimit))
+	require.NoError(t, r1.Close())
+
+	// Seal, leaving r2 as the final reader. The Stream is terminally errored,
+	// so r2 drains the cache then also sees ErrCacheLimit, rather than switching
+	// to a direct read.
+	s.Seal()
+	_, err = io.Copy(io.Discard, r2)
+	require.True(t, errors.Is(err, streamcache.ErrCacheLimit))
+	require.NoError(t, r2.Close())
+}
+
 func TestStreamSource(t *testing.T) {
 	t.Parallel()
 

--- a/streamcache_test.go
+++ b/streamcache_test.go
@@ -1027,6 +1027,29 @@ func TestMaxCacheSize_OverLimitWithBundledEOF(t *testing.T) {
 	require.True(t, errors.Is(s.Err(), streamcache.ErrCacheLimit))
 }
 
+func TestMaxCacheSize_SourceErrorTakesPrecedence(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	const limit = 1000
+	srcErr := errors.New("boom")
+	// The source returns limit+500 bytes together with a non-EOF error in a
+	// single read; those bytes push the cache past the limit. The genuine
+	// source error is reported, not ErrCacheLimit (io.EOF, by contrast, is
+	// superseded by ErrCacheLimit — see TestMaxCacheSize_OverLimitWithBundledEOF).
+	src := newErrorAfterNReader(limit+500, srcErr)
+	s := streamcache.New(src, streamcache.MaxCacheSize(limit))
+	r := s.NewReader(ctx)
+	defer r.Close()
+
+	buf := make([]byte, limit+500)
+	n, err := r.Read(buf)
+	require.Equal(t, limit+500, n)
+	require.True(t, errors.Is(err, srcErr))
+	require.False(t, errors.Is(err, streamcache.ErrCacheLimit))
+	require.True(t, errors.Is(s.Err(), srcErr))
+}
+
 func TestStreamSource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds an optional cap on the size of a `Stream`'s in-memory cache, as requested in #5.

- New functional option: `streamcache.New(src, streamcache.MaxCacheSize(n))`. `New(src)` is unchanged (the new parameter is variadic), so this is backward-compatible.
- New sentinel `streamcache.ErrCacheLimit`. When the source yields more than `n` bytes, the `Read` that grows the cache past `n` returns `ErrCacheLimit` (together with the bytes it read) and the stream enters a terminal state on that same call: `Stream.Err` returns `ErrCacheLimit`, `Stream.Filled` closes, and `Stream.Total` returns it — no subsequent read required.
- The limit guards only the cache-growing path in `readMain`. Once the stream is sealed down to its final reader, that reader reads directly from the source and is **not** subject to the limit (it consumes no cache memory).
- A source of exactly `n` bytes completes normally with `io.EOF` (the check is strictly greater-than). Because detecting "more than `n`" requires reading past `n`, the cache may exceed `n` by at most one source read before the stream is terminated; this is documented on `MaxCacheSize`.
- Docs: godoc on `New`, `MaxCacheSize`, `ErrCacheLimit`, and cross-references on `Err`/`Filled`/`Total`; a "Limiting cache size" section in the README.

## Test Plan

10 tests covering:
- overflow with multiple readers (`Err`/`Filled`/`Total` all reflect `ErrCacheLimit`)
- terminal state set on the crossing read, reflected without any further read
- over-limit source that bundles its final bytes with `io.EOF` still reports `ErrCacheLimit`
- exact-fit source completes with `io.EOF` (boundary)
- `MaxCacheSize(0)` / negative means unlimited
- sealed single reader reads a large source directly, unaffected by the limit
- overflow remains terminal after sealing
- overshoot bounded to `(limit, limit + readbuf]`
- 8-reader concurrency under `-race`

Verification: `go test ./...` and `go test -race ./...` pass; `go vet ./...` clean; `golangci-lint run` reports 0 issues; new code is fully covered (`readMain`/`New`/`MaxCacheSize` at 100%).

Closes #5